### PR TITLE
Simplify SaveInTransactionalBatchAsync

### DIFF
--- a/Contacts.Domain/DomainEntity.cs
+++ b/Contacts.Domain/DomainEntity.cs
@@ -14,6 +14,9 @@ namespace Contacts.Domain
         [JsonProperty] public bool Deleted { get; protected set; }
 
         [JsonIgnore] protected bool IsNew { get; init; }
+        
+        // for multi-threading, this should be migrated to one of the 
+        // concurrent collections of C# 
         private readonly List<IEvent> _events = new();
 
         [JsonIgnore] public IReadOnlyList<IEvent> DomainEvents => _events.AsReadOnly();

--- a/Contacts.Infrastructure/Context/CosmosContainerContext.cs
+++ b/Contacts.Infrastructure/Context/CosmosContainerContext.cs
@@ -22,6 +22,8 @@ namespace Contacts.Infrastructure.Context
             _mediator = mediator;
         }
 
+        // for multi-threading, this should be migrated to one of the 
+        // concurrent collections of C# 
         public List<IDataObject<Entity>> DataObjects { get; } = new();
 
         public void Reset()


### PR DESCRIPTION
This PR removes some redundancy while handling and saving tracked objects to Cosmos DB.

Also: adds comments regarding multi-threading.